### PR TITLE
Add Strawberry into CSS Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The CSS Working Group defines CSS specifications which move through the their pr
 * [Pure.css](http://purecss.io/) - A set of small, responsive CSS modules that you can use in every web project.
 * [Semantic UI](http://semantic-ui.com/) - Powerful framework that uses human-friendly HTML.
 * [Spectre.css](https://picturepan2.github.io/spectre/index.html) - A lightweight, responsive and modern CSS framework.
+* [Strawberry](https://github.com/jfet97/strawberry) - A set of common flexbox's utilities focused on making your life easier and faster with nested flexboxes
 * [Wing](http://usewing.ml) - A Minimal, Lightweight, Responsive framework.
 * [UIkit](http://getuikit.com/) - A lightweight and modular front-end framework.
 * [unsemantic](http://unsemantic.com/) - Fluid grid for mobile, tablet, and desktop.


### PR DESCRIPTION
# What does this PR do?
This is a request to add Strawberry into CSS Framework

# Which issue is this PR related to?


Strawberry is a new flexbox based CSS micro-framework, a set of common flexbox's utilities focused on making life easier and faster with nested flexboxes. You can easily create nested flexboxes directly from the container. (contributing guidelines - point c & d)
So it can also considered like a fallback for CSS Grid. (contributing guidelines - point c & d)


Some good points of it:
1. It's light: less than 12Kb
2. It’s powerful: create Flexbox-based layouts in few lines of code 
3. No preset graphic style: it helps you create layouts without messing up your life 
4. No conflicts with other used framework in the same project: all classes start with the sb- prefix
5. Easy to override: strawberry never use !important (contributing guidelines - point c)


I started this project on June 5th 2018, it is written in SASS and it could be installed using node, forking the repo or using the CDN. (so I am not point a & point b compliant, but maybe this project could be interesting anyway)


Useful links:
* [repo](https://github.com/jfet97/strawberry)
* [wiki](https://github.com/jfet97/strawberry/wiki)
* [website](https://jfet97.github.io/strawberry/)
* [medium](https://medium.com/@andreasimonecosta/strawberry-a-new-flexbox-based-css-micro-framework-42ff9be49468)


