### PR TITLE
Update link to Wing

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The CSS Working Group defines CSS specifications which move through the their pr
 * [Semantic UI](http://semantic-ui.com/) - Powerful framework that uses human-friendly HTML.
 * [Spectre.css](https://picturepan2.github.io/spectre/index.html) - A lightweight, responsive and modern CSS framework.
 * [Strawberry](https://github.com/jfet97/strawberry) - A set of common flexbox's utilities focused on making your life easier and faster with nested flexboxes
-* [Wing](http://usewing.ml) - A Minimal, Lightweight, Responsive framework.
+* [Wing](https://kbrsh.github.io/wing/) - A Minimal, Lightweight, Responsive framework.
 * [UIkit](http://getuikit.com/) - A lightweight and modular front-end framework.
 * [unsemantic](http://unsemantic.com/) - Fluid grid for mobile, tablet, and desktop.
 * [Tachyons](http://tachyons.io/) - Functional CSS for humans.


### PR DESCRIPTION
# What does this PR do?
Updates the Wing CSS Framework website.
The currently linked website has multiple redirects and is very suspect. It looks like Wing does not use that website anymore. Website is linked on the developer's GitHub page, https://github.com/kbrsh/wing.
# Which issue is this PR related to?
N/A

# Does this PR follows our [contribution guidelines](https://github.com/sotayamashita/awesome-css/blob/master/CONTRIBUTING.md)?
Yes