### PR TITLE
Add the Chota framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The CSS Working Group creates and defines CSS specifications. These specificatio
 * [Bootstrap](https://getbootstrap.com/) - The most popular HTML, CSS, and JS framework.
 * [Bulma](http://bulma.io/) - A modern CSS framework based on Flexbox. Also has Sass import for modification.
 * [Butter Cake](http://getbuttercake.com/) - A Modern Lightweight Front End CSS framework for faster and easier web development.
+* [Chota](https://jenil.github.io/chota/) - A responsive, customizable micro-framework (3kb) with helpful utilities and a grid system.
 * [Cirrus](https://spiderpig86.github.io/Cirrus/) - A fully responsive and comprehensive CSS framework with beautiful controls and simplistic structure.
 * [eFrolic](http://efrolicss.com/) - CSS framework which without using JavaScript is interactive and animated.
 * [Foundation](http://foundation.zurb.com/) - advanced responsive front-end framework.


### PR DESCRIPTION
I found Chota at https://jenil.github.io/chota/; I think it could be a great fit for this list since its file size is incredibly small (only about 3 kilobytes) but it has everything from a grid system to customization and even utility classes.

AFAIK my submission follows the contribution guidelines.