### PR TITLE
Add CSS hands-on tutorial to Tutorials section

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ Here is a [CSS in JS techniques comparison](https://github.com/MicheleBertoli/cs
 * [CSS Diner](https://flukeout.github.io/) – Interactive gamified tutorial for learning selection with CSS.
 * [CSS Grid PlayGround](https://mozilladevelopers.github.io/playground/) - Simple tutorial to learn CSS Grid from Mozilla.
 * [CSS Grids videos tutorial](https://cssgrid.io/) - Free video course by Wes Bos to learn CSS Grids.
+* [CSS Hands-on Tutorial](https://labex.io/tutorials/quick-start-with-css-free-tutorials-413795) - Free CSS hands-on tutorial by LabEx.
 * [CSS Math Functions](https://stackdiary.com/css-math-functions/) - Using CSS Math for responsive design.
 * [Flexbox video tutorial](https://flexbox.io/) - Free video course by Wes Bos to learn flexbox.
 * [Organize CSS with a Modular Architecture: OOCSS, BEM, SMACSS](https://snipcart.com/blog/organize-css-modular-architecture) - In-depth intro to OOCSS, BEM, SMACSS, with examples.


### PR DESCRIPTION
# What does this PR do?

Add CSS hands-on tutorial to Tutorials section.

I work at LabEx, a unique learning platform that has delivered thousands of hands-on labs over the past 7 years. This series of free css tutorials is designed based on our Hands-on Labs. You can read them without logging in, and all labs can be run online, making them perfect for beginners.

# Which issue is this PR related to?
> If not related to any issue leave blank.

# Does this PR follows our [contribution guidelines](https://github.com/sotayamashita/awesome-css/blob/master/CONTRIBUTING.md)?

Yes. 
This repo is a great resource. Please let me know if any changes are needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added links and badges for the Awesome CSS project and Travis CI build status.
	- Expanded the "Table of Contents" with categories and resources related to CSS development.
- **Documentation**
	- Clarified the purpose of the curated list in the introduction.
	- Enhanced content under each category with additional links to relevant resources, tools, and libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->