### PR TITLE
Add Pacgie Tools to CSS resources list

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Here is a [CSS in JS techniques comparison](https://github.com/MicheleBertoli/cs
 * [Glassmorphism CSS Generator](https://ui.glass/generator/) - Generate CSS for glassmorphism.
 * [GradientArt](https://gra.dient.art/) - An advanced CSS gradient editor with layering, design tools and free cloud storage.
 * [Live editor for CSS and LESS](https://github.com/webextensions/live-css-editor) - Magic CSS extension for Chrome, Firefox and Edge.
+* [Pacgie Tools](https://www.pacgie.com) - Collection of free CSS generators (gradients, box-shadow, glassmorphism, neumorphism, flexbox, grid).
 * [RevengeCSS](https://github.com/Heydon/REVENGE.CSS) - A CSS bookmarklet that uses selectors to find bad markup, displaying ugly pink error messages in comic sans serif wherever you write bad HTML
 * [Single Div Project](https://github.com/ManrajGrover/SingleDivProject) - One `<div>`. Many possibilities.
 * [You Might Not Need JS](http://youmightnotneedjs.com/) - CSS alternatives for common JS UI components.

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Here is a [CSS in JS techniques comparison](https://github.com/MicheleBertoli/cs
 * [Glassmorphism CSS Generator](https://ui.glass/generator/) - Generate CSS for glassmorphism.
 * [GradientArt](https://gra.dient.art/) - An advanced CSS gradient editor with layering, design tools and free cloud storage.
 * [Live editor for CSS and LESS](https://github.com/webextensions/live-css-editor) - Magic CSS extension for Chrome, Firefox and Edge.
-* [Pacgie Tools](https://www.pacgie.com) - Collection of free CSS generators (gradients, box-shadow, glassmorphism, neumorphism, flexbox, grid).
+* [Pacgie Tools](https://www.pacgie.com) - Collection of free CSS generators.
 * [RevengeCSS](https://github.com/Heydon/REVENGE.CSS) - A CSS bookmarklet that uses selectors to find bad markup, displaying ugly pink error messages in comic sans serif wherever you write bad HTML
 * [Single Div Project](https://github.com/ManrajGrover/SingleDivProject) - One `<div>`. Many possibilities.
 * [You Might Not Need JS](http://youmightnotneedjs.com/) - CSS alternatives for common JS UI components.


### PR DESCRIPTION
Adding Pacgie - a collection of free, no-signup CSS generator tools including:
   - CSS Gradient Generator
   - Box Shadow Generator
   - Glassmorphism Generator
   - Neumorphism Generator
   - Flexbox Generator
   - CSS Grid Generator
   
   All tools are free, fast, and require no registration.
   
   Website: https://www.pacgie.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a reference to "Pacgie Tools" — a collection of free CSS generators — in the miscellaneous resources section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->