### PR TITLE
Add DevTools CSS Gradient Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Here is a [CSS in JS techniques comparison](https://github.com/MicheleBertoli/cs
 * [Flexbox Patterns](https://flexboxpatterns.com/) by cjcenizal
 * [Glassmorphism CSS Generator](https://ui.glass/generator/) - Generate CSS for glassmorphism.
 * [GradientArt](https://gra.dient.art/) - An advanced CSS gradient editor with layering, design tools and free cloud storage.
+* [DevTools CSS Gradient Generator](https://devtools.davrapps.dev/en/gradient-generator) - Visual CSS gradient generator with linear, radial, and conic support. Outputs CSS and Tailwind classes. 100% client-side.
 * [Live editor for CSS and LESS](https://github.com/webextensions/live-css-editor) - Magic CSS extension for Chrome, Firefox and Edge.
 * [RevengeCSS](https://github.com/Heydon/REVENGE.CSS) - A CSS bookmarklet that uses selectors to find bad markup, displaying ugly pink error messages in comic sans serif wherever you write bad HTML
 * [Single Div Project](https://github.com/ManrajGrover/SingleDivProject) - One `<div>`. Many possibilities.

--- a/README.md
+++ b/README.md
@@ -264,10 +264,10 @@ Here is a [CSS in JS techniques comparison](https://github.com/MicheleBertoli/cs
 
 * [Beautiful CSS box-shadow examples](https://getcssscan.com/css-box-shadow-examples) - Curated collection of 93 beautiful CSS box-shadow. Click to copy.
 * [Can I use](https://caniuse.com/) - Browser support for CSS, HTML5 and other front-end web technologies.
+* [DevTools CSS Gradient Generator](https://devtools.davrapps.dev/en/gradient-generator) - Visual CSS gradient generator with linear, radial, and conic support. Outputs CSS and Tailwind classes. 100% client-side.
 * [Flexbox Patterns](https://flexboxpatterns.com/) by cjcenizal
 * [Glassmorphism CSS Generator](https://ui.glass/generator/) - Generate CSS for glassmorphism.
 * [GradientArt](https://gra.dient.art/) - An advanced CSS gradient editor with layering, design tools and free cloud storage.
-* [DevTools CSS Gradient Generator](https://devtools.davrapps.dev/en/gradient-generator) - Visual CSS gradient generator with linear, radial, and conic support. Outputs CSS and Tailwind classes. 100% client-side.
 * [Live editor for CSS and LESS](https://github.com/webextensions/live-css-editor) - Magic CSS extension for Chrome, Firefox and Edge.
 * [RevengeCSS](https://github.com/Heydon/REVENGE.CSS) - A CSS bookmarklet that uses selectors to find bad markup, displaying ugly pink error messages in comic sans serif wherever you write bad HTML
 * [Single Div Project](https://github.com/ManrajGrover/SingleDivProject) - One `<div>`. Many possibilities.


### PR DESCRIPTION
Added [DevTools CSS Gradient Generator](https://devtools.davrapps.dev/en/gradient-generator) to the Style Guide Generators section.

**What it does:** Visual CSS gradient editor supporting linear, radial, and conic gradients. Multiple color stops, angle control, 8 preset gradients. Outputs both standard CSS and Tailwind CSS classes.

**Why it fits:** Alongside existing entries like Glassmorphism CSS Generator and GradientArt — it's a focused, free, client-side CSS tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a curated resource entry for a CSS gradient generator that creates linear, radial, and conic gradients and outputs ready-to-use CSS and Tailwind classes; the tool runs fully client-side and is listed under miscellaneous resources for quick access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->